### PR TITLE
feat(checks): add checks on CloudRun services

### DIFF
--- a/gcp/cloudrun/cloudrun.go
+++ b/gcp/cloudrun/cloudrun.go
@@ -1,0 +1,56 @@
+package cloudrun
+
+import (
+	"sync"
+
+	"cloud.google.com/go/run/apiv2/runpb"
+	"github.com/padok-team/yatas-gcp/internal"
+	"github.com/padok-team/yatas/plugins/commons"
+)
+
+type CloudRunService struct {
+	Service runpb.Service
+}
+
+func (c *CloudRunService) GetID() string {
+	return c.Service.Name
+}
+
+func RunChecks(wa *sync.WaitGroup, account internal.GCPAccount, c *commons.Config, queue chan []commons.Check) {
+	var checkConfig commons.CheckConfig
+	checkConfig.Init(c)
+	var checks []commons.Check
+
+	services := GetCloudRunServices(account)
+
+	cloudrunChecks := []commons.CheckDefinition{
+		{
+			Title:          "GCP_RUN_001",
+			Description:    "CloudRun services are not directly exposed on the internet",
+			Categories:     []string{"Security", "Good Practice"},
+			ConditionFn:    CloudRunServiceIsInternal,
+			SuccessMessage: "Service is exposed internally or through a load balancer",
+			FailureMessage: "Service is directly exposed on the internet",
+		},
+	}
+
+	var resources []commons.Resource
+	for _, svc := range services {
+		resources = append(resources, &CloudRunService{Service: svc})
+	}
+	commons.AddChecks(&checkConfig, cloudrunChecks)
+	go commons.CheckResources(checkConfig, resources, cloudrunChecks)
+
+	go func() {
+		for t := range checkConfig.Queue {
+			t.EndCheck()
+			checks = append(checks, t)
+
+			checkConfig.Wg.Done()
+		}
+	}()
+
+	checkConfig.Wg.Wait()
+
+	queue <- checks
+}

--- a/gcp/cloudrun/cloudrun.go
+++ b/gcp/cloudrun/cloudrun.go
@@ -40,6 +40,14 @@ func RunChecks(wa *sync.WaitGroup, account internal.GCPAccount, c *commons.Confi
 			SuccessMessage: "Service is not using the default Compute Engine service account",
 			FailureMessage: "Service is using the default Compute Engine service account",
 		},
+		{
+			Title:          "GCP_RUN_003",
+			Description:    "CloudRun services do not have plain text secrets in environment variables",
+			Categories:     []string{"Security", "Good Practice"},
+			ConditionFn:    CloudRunServiceDoesNotHaveSecretInEnv,
+			SuccessMessage: "Service SEEMS to not have plain text secrets in environment variables, check manually",
+			FailureMessage: "Service MIGHT have plain text secrets in environment variables, check manually",
+		},
 	}
 
 	var resources []commons.Resource

--- a/gcp/cloudrun/cloudrun.go
+++ b/gcp/cloudrun/cloudrun.go
@@ -32,6 +32,14 @@ func RunChecks(wa *sync.WaitGroup, account internal.GCPAccount, c *commons.Confi
 			SuccessMessage: "Service is exposed internally or through a load balancer",
 			FailureMessage: "Service is directly exposed on the internet",
 		},
+		{
+			Title:          "GCP_RUN_002",
+			Description:    "CloudRun services do not use the default Compute Engine service account",
+			Categories:     []string{"Security", "Good Practice"},
+			ConditionFn:    CloudRunServiceIsNotUsingDefaultSA,
+			SuccessMessage: "Service is not using the default Compute Engine service account",
+			FailureMessage: "Service is using the default Compute Engine service account",
+		},
 	}
 
 	var resources []commons.Resource

--- a/gcp/cloudrun/cloudrunConditions.go
+++ b/gcp/cloudrun/cloudrunConditions.go
@@ -1,16 +1,32 @@
 package cloudrun
 
 import (
+	"regexp"
+
 	"cloud.google.com/go/run/apiv2/runpb"
 	"github.com/padok-team/yatas/plugins/commons"
 )
+
+// The default Compute Engine service account is always PROJECT_NUMBER-compute@developer.gserviceaccount.com
+func isDefaultComputeEngineSA(name string) bool {
+	regionPattern := regexp.MustCompile(`^[0-9]+-compute@developer\.gserviceaccount\.com$`)
+	return regionPattern.MatchString(name)
+}
 
 func CloudRunServiceIsInternal(resource commons.Resource) bool {
 	svc, ok := resource.(*CloudRunService)
 	if !ok {
 		return false
 	}
-
 	return svc.Service.Ingress == runpb.IngressTraffic_INGRESS_TRAFFIC_INTERNAL_ONLY ||
 		svc.Service.Ingress == runpb.IngressTraffic_INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER
+}
+
+func CloudRunServiceIsNotUsingDefaultSA(resource commons.Resource) bool {
+	svc, ok := resource.(*CloudRunService)
+	if !ok {
+		return false
+	}
+	sa := svc.Service.GetTemplate().GetServiceAccount()
+	return sa != "" && !isDefaultComputeEngineSA(sa)
 }

--- a/gcp/cloudrun/cloudrunConditions.go
+++ b/gcp/cloudrun/cloudrunConditions.go
@@ -30,3 +30,34 @@ func CloudRunServiceIsNotUsingDefaultSA(resource commons.Resource) bool {
 	sa := svc.Service.GetTemplate().GetServiceAccount()
 	return sa != "" && !isDefaultComputeEngineSA(sa)
 }
+
+func mayBeSensitive(name string, value string) bool {
+	privateKeyPattern := regexp.MustCompile(`-----BEGIN (RSA|EC|DSA|GPP|OPENSSH) PRIVATE KEY-----`)
+	namePattern := regexp.MustCompile(`(key|secret|password|token|private|credential|auth|certificate|cert|pem|ssl|tls|ssh|rsa|ecdsa|dsa|gpp)(?i)`)
+
+	return namePattern.MatchString(name) || privateKeyPattern.MatchString(value)
+}
+
+func CloudRunServiceDoesNotHaveSecretInEnv(resource commons.Resource) bool {
+	svc, ok := resource.(*CloudRunService)
+	if !ok {
+		return false
+	}
+	template := svc.Service.GetTemplate()
+	if template == nil {
+		return false
+	}
+	containers := template.GetContainers()
+	for _, container := range containers {
+		envVars := container.GetEnv()
+		for _, envVar := range envVars {
+			name := envVar.GetName()
+			// If GetValue returns an empty string, it means that the env var may be a secret ref, so we do not check it
+			value := envVar.GetValue()
+			if value != "" && mayBeSensitive(name, value) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/gcp/cloudrun/cloudrunConditions.go
+++ b/gcp/cloudrun/cloudrunConditions.go
@@ -1,0 +1,16 @@
+package cloudrun
+
+import (
+	"cloud.google.com/go/run/apiv2/runpb"
+	"github.com/padok-team/yatas/plugins/commons"
+)
+
+func CloudRunServiceIsInternal(resource commons.Resource) bool {
+	svc, ok := resource.(*CloudRunService)
+	if !ok {
+		return false
+	}
+
+	return svc.Service.Ingress == runpb.IngressTraffic_INGRESS_TRAFFIC_INTERNAL_ONLY ||
+		svc.Service.Ingress == runpb.IngressTraffic_INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER
+}

--- a/gcp/cloudrun/getter.go
+++ b/gcp/cloudrun/getter.go
@@ -1,0 +1,43 @@
+package cloudrun
+
+import (
+	"context"
+
+	run "cloud.google.com/go/run/apiv2"
+	"cloud.google.com/go/run/apiv2/runpb"
+	"github.com/padok-team/yatas-gcp/internal"
+	"github.com/padok-team/yatas-gcp/logger"
+	"google.golang.org/api/iterator"
+)
+
+func GetCloudRunServices(account internal.GCPAccount) []runpb.Service {
+	ctx := context.Background()
+
+	c, err := run.NewServicesClient(ctx)
+	if err != nil {
+		logger.Logger.Error("Failed to create CloudRun Services client", "error", err)
+	}
+	defer c.Close()
+
+	var services []runpb.Service
+
+	for _, region := range account.ComputeRegions {
+		req := &runpb.ListServicesRequest{
+			Parent: "projects/" + account.Project + "/locations/" + region,
+		}
+		it := c.ListServices(ctx, req)
+		for {
+			resp, err := it.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				logger.Logger.Error("Failed to list CloudRun services", "error", err.Error())
+			}
+			services = append(services, *resp)
+		}
+	}
+
+	return services
+
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/compute v1.23.0
 	cloud.google.com/go/container v1.26.0
 	cloud.google.com/go/iam v1.1.2
+	cloud.google.com/go/run v1.2.0
 	cloud.google.com/go/storage v1.33.0
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-plugin v1.4.10
@@ -17,6 +18,7 @@ require (
 require (
 	cloud.google.com/go v0.110.6 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
+	cloud.google.com/go/longrunning v0.5.1 // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,10 @@ cloud.google.com/go/container v1.26.0 h1:SszQdI0qlyKsImz8/l26rpTZMyqvaH9yfua7rir
 cloud.google.com/go/container v1.26.0/go.mod h1:YJCmRet6+6jnYYRS000T6k0D0xUXQgBSaJ7VwI8FBj4=
 cloud.google.com/go/iam v1.1.2 h1:gacbrBdWcoVmGLozRuStX45YKvJtzIjJdAolzUs1sm4=
 cloud.google.com/go/iam v1.1.2/go.mod h1:A5avdyVL2tCppe4unb0951eI9jreack+RJ0/d+KUZOU=
+cloud.google.com/go/longrunning v0.5.1 h1:Fr7TXftcqTudoyRJa113hyaqlGdiBQkp0Gq7tErFDWI=
+cloud.google.com/go/longrunning v0.5.1/go.mod h1:spvimkwdz6SPWKEt/XBij79E9fiTkHSQl/fRUUQJYJc=
+cloud.google.com/go/run v1.2.0 h1:kHeIG8q+N6Zv0nDkBjSOYfK2eWqa5FnaiDPH/7/HirE=
+cloud.google.com/go/run v1.2.0/go.mod h1:36V1IlDzQ0XxbQjUx6IYbw8H3TJnWvhii963WW3B/bo=
 cloud.google.com/go/storage v1.33.0 h1:PVrDOkIC8qQVa1P3SXGpQvfuJhN2LHOoyZvWs8D2X5M=
 cloud.google.com/go/storage v1.33.0/go.mod h1:Hhh/dogNRGca7IWv1RC2YqEn0c0G77ctA/OxflYkiD8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
+	"github.com/padok-team/yatas-gcp/gcp/cloudrun"
 	"github.com/padok-team/yatas-gcp/gcp/gcs"
 	"github.com/padok-team/yatas-gcp/gcp/gke"
 	"github.com/padok-team/yatas-gcp/gcp/instance"
@@ -95,6 +96,7 @@ func initTest(account internal.GCPAccount, c *commons.Config) commons.Tests {
 	go commons.CheckMacroTest(&wg, c, sql.RunChecks)(&wg, account, c, queue)
 	go commons.CheckMacroTest(&wg, c, loadbalancing.RunChecks)(&wg, account, c, queue)
 	go commons.CheckMacroTest(&wg, c, gke.RunChecks)(&wg, account, c, queue)
+	go commons.CheckMacroTest(&wg, c, cloudrun.RunChecks)(&wg, account, c, queue)
 
 	go func() {
 		for t := range queue {


### PR DESCRIPTION
- [x] **GCP_RUN_001:** CloudRun services are not directly exposed on the internet
- [x] **GCP_RUN_002:** CloudRun services do not use the default Compute Engine service account
- [x] **GCP_RUN_003:** CloudRun services does not have sensitive values in their environment (use secret manager instead)